### PR TITLE
Upgrade to latest Font Awesome

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ go 1.13
 // FontAwesome does not use a proper semantic version (starting with 'v'), hence the following:
 // require github.com/FortAwesome/Font-Awesome 5.15.3
 // ... resolves to:
-require github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8
+require github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8 h1:3h1ZlZmKNqZtiTD6FF7GijnIB/PU9/jR+dclHF80pFE=
-github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f h1:3/aWi2Aq8yQsulhJo1lS3NJ3ytCyXNHorms/GoZHn78=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=


### PR DESCRIPTION
Upgrade to latest version [6.7.1](https://github.com/FortAwesome/Font-Awesome/tree/6.7.1) of Font Awesome. This version includes new SVG icons such as Bluesky.

Note that some SVGs got renamed since the last version so I had to change these values in Osprey Delight v5.0.7 [icons.yml](https://github.com/kdevo/osprey-delight/blob/v5.0.7/data/icons.yaml) to get the theme to work:

```
# General
warning:
  id: fas triangle-exclamation
  title: Warning

# Modal
close: 
  id: fas x
  title: Close

# Contact
sending: fas shuttle-space
ok: fas circle-check
```